### PR TITLE
Add hardened .npmrc for supply-chain security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Supply-chain hardening directives (SC-12282 / APS-19730)
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+engine-strict=true
+legacy-peer-deps=false
+audit-level=high


### PR DESCRIPTION
Adds a hardened `.npmrc` enforcing npm supply-chain best practices:

```ini
ignore-scripts=true
strict-ssl=true
save-exact=true
engine-strict=true
legacy-peer-deps=false
audit-level=high
```

Notes:
- Verified: `npm ci` against the committed package-lock.json on Node 14, 18, 20, and 22 — lockfile unchanged; sample test run verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
